### PR TITLE
Distinguish between suspend and abort in the simulation step function.

### DIFF
--- a/arch/proc/ExecuteStage.cpp
+++ b/arch/proc/ExecuteStage.cpp
@@ -453,7 +453,7 @@ void Processor::Pipeline::ExecuteStage::ExecStatusAction(Integer value, int comm
     case 1: 
         // interrupt the simulation in a way that is resumable
         // from the interactive prompt.
-        GetKernel()->Abort();
+        GetKernel()->Stop();
         break;
     case 2:
         abort();

--- a/sim/breakpoints.cpp
+++ b/sim/breakpoints.cpp
@@ -216,7 +216,7 @@ void BreakPoints::CheckMore(int type, MemAddr addr, Object& obj)
         {
             ActiveBreak ab(addr, obj, i->second.type & type);
             m_activebreaks.insert(ab);
-            m_kernel.Abort();
+            m_kernel.Stop();
         }
     }
 }

--- a/sim/kernel.h
+++ b/sim/kernel.h
@@ -245,7 +245,8 @@ public:
     
 private:
     bool                m_aborted;      ///< Should the run be aborted?
-    CycleNo             m_lastabort;    ///< Avoid aborting twice on the same cycle.
+    bool                m_suspended;    ///< Should the run be suspended?
+    CycleNo             m_lastsuspend;  ///< Avoid suspending twice on the same cycle.
     int	                m_debugMode;    ///< Bit mask of enabled debugging modes.
     CycleNo             m_cycle;        ///< Current cycle of the simulation.
     SymbolTable&        m_symtable;     ///< The symbol table for debugging.
@@ -327,10 +328,18 @@ public:
     
     /**
      * @brief Aborts the simulation
-     * Aborts the current simulation, in Step(). This is best called asynchronously,
-     * from a signal handler. Step() will return STATE_ABORTED.
+     * Stops the current simulation, in Step(). This is best called asynchronously,
+     * from a signal handler. Step() will return STATE_ABORTED. The simulation cannot be resumed.
      */
     void Abort();
+
+    /**
+     * @brief Suspends the simulation
+     * Stops the current simulation, in Step(). This is best called asynchronously,
+     * from a signal handler. Step() will return STATE_ABORTED. Next call to Step()
+     * will resume the simulation.
+     */
+    void Stop();
 
     /**
      * @brief Get all components.


### PR DESCRIPTION
The original implementation supported only complete abort of the
simulation. A while ago breakpoints ("bp ..." on the interactive
prompt) and program-driven simulation exceptions have been introduced,
but were implemented using the original abort mechanism, which
prevented any form of resumption. A later patch made all aborts
resumable, which was incorrect for anything but breakpoints and
program-driven exceptions. This patch addresses the situation by
providing separate support for aborts and "resumable exceptions". The
latter is used for breakpoints and program-driven exceptions, while
the former is used for simulaiton errors.
