### PR TITLE
Ensure that exclusive families get created on only 1 core.

### DIFF
--- a/arch/proc/Allocator.cpp
+++ b/arch/proc/Allocator.cpp
@@ -976,6 +976,9 @@ bool Processor::Allocator::QueueFamilyAllocation(const RemoteMessage& msg, bool 
     // Can't be balanced; that should have been handled by
     // the network before it gets here.
     assert(msg.allocate.type != ALLOCATE_BALANCED);
+
+    // Can't be exclusive and non-single.
+    assert(!msg.allocate.exclusive || msg.allocate.type == ALLOCATE_SINGLE);
     
     // Place the request in the appropriate buffer
     AllocRequest request;

--- a/arch/proc/ExecuteStage.cpp
+++ b/arch/proc/ExecuteStage.cpp
@@ -188,11 +188,11 @@ Processor::Pipeline::PipeAction Processor::Pipeline::ExecuteStage::ExecAllocate(
     }
     
     AllocationType type = (AllocationType)(flags & 3);
-    if (exclusive && type == ALLOCATE_BALANCED)
+    if (exclusive && type != ALLOCATE_SINGLE)
     {
         type = ALLOCATE_SINGLE;
         
-        DebugSimWrite("F%u/T%u(%llu) %s adjusted allocate type exclusive balanced -> exclusive single",
+        DebugSimWrite("F%u/T%u(%llu) %s adjusted allocate type exclusive -> exclusive single",
                       (unsigned)m_input.fid, (unsigned)m_input.tid, (unsigned long long)m_input.logical_index, m_input.pc_sym);
     }
         


### PR DESCRIPTION
Until this point an exclusive allocate (allocate/x) would only reserve
an exclusive context on the 1st target core, then propagate a "normal"
allocation request to the remainder of the place. This patch changes
this behavior so that "allocate/x" entails the flag "single", ie
propagate the place ID but allocate on only 1 core.
